### PR TITLE
Add a function to turn a `Translation_unit.Error.t` into a string

### DIFF
--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -194,6 +194,10 @@ module Error = struct
             Format.fprintf fmt
               "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;
             if debug then Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
+
+  let to_string ?(debug = false) ?(quiet = false) x =
+    print ~debug ~quiet Format.str_formatter x ;
+    Format.flush_str_formatter ()
 end
 
 let with_file input_name output_file suf ext f =

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -17,6 +17,8 @@ module Error : sig
   val equal : t -> t -> bool
 
   val print : ?debug:bool -> ?quiet:bool -> Format.formatter -> t -> unit
+
+  val to_string : ?debug:bool -> ?quiet:bool -> t -> string
 end
 
 val parse_and_format :


### PR DESCRIPTION
`Translation_unit.parse_and_format` returns values of type `(string, Translation_unit.Error.t) result`.

However, the only thing that we can do with `Translation_unit.Error.t` is printing it to a formatter, with `Translation_unit.Error.print`. 

We might as well want to turn it into a string: It will be useful to print errors when a call to `Translation_unit.parse_and_format` fails.